### PR TITLE
docs: update documentation and add workflow protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: ci
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/protect-main-from-non-dev.yml
+++ b/.github/workflows/protect-main-from-non-dev.yml
@@ -2,14 +2,23 @@ name: protect-main-from-non-dev
 
 on:
   pull_request:
-    branches: [ main ]
+    types: [opened, synchronize, reopened]
 
 jobs:
   only-dev:
     runs-on: ubuntu-latest
     steps:
-      - name: Ensure PR source is dev
-        if: ${{ github.head_ref != 'dev' }}
+      - name: Pass on non-main PRs
+        if: ${{ github.base_ref != 'main' }}
+        run: |
+          echo "Not targeting main; passing protection check. Base='${{ github.base_ref }}'"
+          exit 0
+      - name: Fail if head is not dev (when targeting main)
+        if: ${{ github.base_ref == 'main' && github.head_ref != 'dev' }}
         run: |
           echo "PRs to main must come from 'dev'. Got '${GITHUB_HEAD_REF}'."
           exit 1
+      - name: OK dev -> main
+        if: ${{ github.base_ref == 'main' && github.head_ref == 'dev' }}
+        run: |
+          echo "Valid: dev -> main"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Pantstack is a batteries-included monorepo template for layered services with Pa
 - CI/CD for lint, typecheck, tests, package, deploy, and PR preview stacks
 - Pulumi Cloud (Free) backend; optional ESC (Environments) integration
 
+Prerequisites:
+- Python 3.12 (repo is pinned to 3.12.* in `pants.toml`)
+
 ## Quick Start (Template Author)
 
 Prerequisites:
@@ -164,3 +167,5 @@ Notes:
 - Read and follow `SETUP_CHECKLIST.md`
 - For Pulumi Cloud Free, set `PULUMI_ORG` to your username.
 - Run `make bootstrap` and then `make seed-stacks`.
+
+See `AGENTS.md` for an agents playbook covering structure, commands, and reusable components.

--- a/docs/getting-started/creating-projects.md
+++ b/docs/getting-started/creating-projects.md
@@ -125,9 +125,9 @@ Your new project will have:
 
 ```
 your-project/
-├── modules/           # Service modules
-│   └── api/          # Example API module
-├── platform/         # Shared platform code
+├── services/         # Layered services (app/domain/adapters/public/infra/tests)
+├── modules/          # Optional modules (backend/*, infrastructure)
+├── stack/            # Shared libs, events, and infra components
 ├── .github/          # GitHub Actions workflows
 ├── pants.toml        # Pants build configuration
 ├── docker-compose.yml # Local development

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -8,7 +8,7 @@ Before you begin, ensure you have the following installed:
 
 - **Git**: Version control system
 - **GitHub CLI** (`gh`): For GitHub operations
-- **Python 3.11+**: Required for Pants and services
+- **Python 3.12**: Required for Pants and services (repo pins 3.12.*)
 - **Docker**: For local development and packaging
 - **AWS CLI**: For AWS deployments (optional for template)
 - **Pulumi CLI**: For infrastructure management (optional for template)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # Pantstack
 
-Pantstack is a batteries-included monorepo template for modular services with Pants, FastAPI, Pulumi on AWS, and GitHub Actions.
+Pantstack is a batteries-included monorepo template for layered services and modules with Pants, FastAPI, Pulumi on AWS, and GitHub Actions.
 
-- True module independence (per-module infra, packaging, and tests)
+- Service/module independence (per-target resolves, infra, packaging, and tests)
 - Safe cross-module reuse via public facades and optional HTTP SDKs
 - Single ECR per project; image tags encode module + branch + version
 - CI/CD for lint, typecheck, tests, package, deploy, and PR preview stacks
@@ -111,11 +111,12 @@ make new-project  # Interactive prompts for all values
 
 ## Commands You’ll Use Often
 
-- `make new-module M=orders` — scaffold a new module
-- `make mod M=api` — test and package a module
-- `make stack-up M=api ENV=test` — apply a stack locally
-- `make stack-verify M=api ENV=test` — E2E verify
-- `make gha-deploy M=api ENV=prod` — trigger deploy workflow
+- `make new-service S=writer` — scaffold a new layered service under `services/writer`
+- `make new-module M=orders` — scaffold a new module under `modules/orders`
+- `make mod-s S=web` — test and package a service
+- `make svc-stack-up S=web ENV=test` — deploy a service stack
+- `make svc-stack-outputs S=web ENV=test` — show stack outputs
+- `make gha-deploy M=api ENV=prod` — trigger deploy workflow (module example)
 
 ## Versioning & Promotion
 
@@ -126,9 +127,19 @@ make new-project  # Interactive prompts for all values
 
 ## Architecture
 
-- See `modules/api` for a demo FastAPI + SQS worker and its Pulumi infra.
-- Foundation infra (template bootstrap): `platform/infra/foundation` via Pulumi.
-- Shared libs under `platform/libs/shared` and `platform/events`.
+- Services live under `services/<svc>` with layered folders:
+  - `app/{api,worker}` — FastAPI routers and workers
+  - `domain/{models,services,ports}` — business logic and interfaces
+  - `adapters/{repositories,clients}` — concrete adapters
+  - `public/` — facades for cross-service access
+  - `infra/pulumi/` — ECS/Fargate and supporting AWS infra
+  - `tests/{unit,integration,e2e}` — tests
+- Modules live under `modules/<module>` with `backend/*` and `infrastructure/` (Pulumi).
+- Shared libs under `stack/*`:
+  - `stack/libs/shared` (logging, settings, aws)
+  - `stack/events` (event contracts)
+  - `stack/infra/components` (ECS HTTP/Worker, Redis)
+  - Foundation: `stack/infra/foundation` (shared VPC, ECR, GH setup)
 
 ## First-time Checklist
 


### PR DESCRIPTION
## Summary

Describe the change and the motivation.

## Checklist

- [ ] Tests pass locally (`make test`) and in CI
- [ ] Pre-commit passes locally (`pre-commit run --all-files`)
- [ ] If infra changes, PR preview or preview plan reviewed
- [ ] Docs/README updated if needed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated prerequisites to Python 3.12 and linked an agents playbook.
  * Reframed architecture to “layered services and modules” with revised project structure (services/, modules/, stack/).
  * Refreshed quick start, commands, and reference to service-focused workflows and scaffolding (new-service, svc-stack-*), added Pulumi Cloud mention, adjusted deployment/CI guidance, and streamlined onboarding.

* **Chores**
  * CI/PR workflows: refined event triggers to opened/synchronize/reopened and push scopes; enforces PRs into main originate from dev; non-main targets bypass the main-branch check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->