### PR TITLE
ci(protection): run on all PRs, auto-pass on non-main; enforce dev->m…

### DIFF
--- a/.github/workflows/protect-main-from-non-dev.yml
+++ b/.github/workflows/protect-main-from-non-dev.yml
@@ -2,14 +2,23 @@ name: protect-main-from-non-dev
 
 on:
   pull_request:
-    branches: [ main ]
+    types: [opened, synchronize, reopened]
 
 jobs:
   only-dev:
     runs-on: ubuntu-latest
     steps:
-      - name: Ensure PR source is dev
-        if: ${{ github.head_ref != 'dev' }}
+      - name: Pass on non-main PRs
+        if: ${{ github.base_ref != 'main' }}
+        run: |
+          echo "Not targeting main; passing protection check. Base='${{ github.base_ref }}'"
+          exit 0
+      - name: Fail if head is not dev (when targeting main)
+        if: ${{ github.base_ref == 'main' && github.head_ref != 'dev' }}
         run: |
           echo "PRs to main must come from 'dev'. Got '${GITHUB_HEAD_REF}'."
           exit 1
+      - name: OK dev -> main
+        if: ${{ github.base_ref == 'main' && github.head_ref == 'dev' }}
+        run: |
+          echo "Valid: dev -> main"


### PR DESCRIPTION
…ain only

## Summary

Describe the change and the motivation.

## Version Impact (Required for dev→main PRs)

**⚠️ For PRs from `dev` to `main`, you MUST add ONE of these labels:**
- `release:major` - Breaking changes (1.0.0 → 2.0.0)
- `release:minor` - New features (1.0.0 → 1.1.0)
- `release:patch` - Bug fixes (1.0.0 → 1.0.1)
- `release:skip` - No version bump needed (docs, CI tweaks)

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format OR has a release label
- [ ] For dev→main PRs: Added appropriate version label (see above)
- [ ] Tests pass locally (`make test`) and in CI
- [ ] Pre-commit passes locally (`pre-commit run --all-files`)
- [ ] If infra changes, PR preview or preview plan reviewed
- [ ] Docs/README updated if needed
